### PR TITLE
fix: Footer’s svg size in IE

### DIFF
--- a/components/Footer/style.ts
+++ b/components/Footer/style.ts
@@ -49,6 +49,11 @@ export const SIconList = styled.ul`
   padding: 0;
   text-align: center;
 
+  a svg {
+    width: 1em;
+    height: 1em;
+  }
+
   @media (min-width: 1200px) {
     margin: 0;
   }
@@ -57,11 +62,6 @@ export const SIconList = styled.ul`
 export const SIcon = styled.a`
   margin-right: 22px;
   font-size: 22px;
-
-  svg {
-    width: 1em;
-    height: 1em;
-  }
 
   @media (min-width: 1200px) {
     margin-right: 24px;

--- a/components/Footer/style.ts
+++ b/components/Footer/style.ts
@@ -58,6 +58,11 @@ export const SIcon = styled.a`
   margin-right: 22px;
   font-size: 22px;
 
+  svg {
+    width: 1em;
+    height: 1em;
+  }
+
   @media (min-width: 1200px) {
     margin-right: 24px;
     font-size: 21px;

--- a/views/Post/style.ts
+++ b/views/Post/style.ts
@@ -40,6 +40,11 @@ export const SBox1 = styled.div`
   display: -webkit-box;
   -webkit-box-align: center;
   align-items: center;
+  :after {
+    content:'';
+    min-height:inherit;
+    font-size:0;
+  }
 
   @media (min-width: 1200px) {
     width: 1170px;


### PR DESCRIPTION
1. Fixed svg size.
2. Fixed the article page title not being centered in IE.