### PR TITLE
fix: broken links in apisix vs api7

### DIFF
--- a/_posts/page/en-US/apisix-vs-api7.md
+++ b/_posts/page/en-US/apisix-vs-api7.md
@@ -16,5 +16,5 @@ date: 2020-11-13 14:54:00
 |                                                             ARM64 Support                                                             |                         SSL Certificate Management                          |
 |                                                Support key-auth, JWT, basic-auth，IdP                                                 |                          Enterprise-Class Security                          |
 |                                                            Fault Injection                                                            |                             More Paid Plug-Ins                              |
-| For further functions, please refer to：[Click to view](https://github.com/apache/apisix/blob/master/README_CN.md#%E5%8A%9F%E8%83%BD) | [SLA-Based Business Support](https://www.apiseven.com/business-support) |
+| For further functions, please refer to：[Click to view](https://github.com/apache/apisix/blob/e9a59ac5e8618737f69eddbaf05097b7ffab46ff/README.md#features) | [SLA-Based Business Support](https://www.apiseven.com/business-support) |
 |                                           [Download Now](https://github.com/apache/apisix)                                            |           [Request a Demo](https://apiseven.mikecrm.com/pvdVjd5)            |

--- a/_posts/page/zh-CN/apisix-vs-api7.md
+++ b/_posts/page/zh-CN/apisix-vs-api7.md
@@ -16,5 +16,5 @@ date: 2020-11-12 18:18:00
 |                                                支持 ARM64                                                |                             SSL 证书管理                             |
 |                                   支持 key-auth, JWT, basic-auth，IdP                                    |                              企业级安全                              |
 |                                                 故障注入                                                 |                             更多付费插件                             |
-| 更多功能可参考：[点击查看](https://github.com/apache/apisix/blob/master/README_CN.md#%E5%8A%9F%E8%83%BD) | [基于 SLA 的商业支持](https://www.apiseven.com/business-support) |
+| 更多功能可参考：[点击查看](https://github.com/apache/apisix/blob/2ee828b2eebc31d03d6ac3d701c722ea1166cde1/docs/zh/latest/README.md#%E7%89%B9%E6%80%A7) | [基于 SLA 的商业支持](https://www.apiseven.com/business-support) |
 |                               [现在下载](https://github.com/apache/apisix)                               |           [申请演示](https://apiseven.mikecrm.com/pvdVjd5)           |


### PR DESCRIPTION
## Background 
When browsing the page of [apisix vs api7](http://localhost:3000/zh/apisix-vs-api7), got some broken links. 

## Change
I checked the link location in [apisix](https://github.com/apache/apisix), and updated the links in website.

## Test
No code change.