### PR TITLE
fix: Irregular word-breaks in blog, job description pages and font face, styling in job description pages

### DIFF
--- a/_posts/careers/en-US/customer-success-architect.md
+++ b/_posts/careers/en-US/customer-success-architect.md
@@ -3,23 +3,23 @@ title: Customer Success Architect
 date: 2021-02-23 11:10:00
 ---
 
-### Content
+## Content
 
-1. Are you eager to share brand new technologies with the world?
-2. Do you love connecting with community members in a variety of ways, whether it's face-to-face, blogs, forums or other social channels and events?
-3. Do you love sharing your enthusiasm for Apache APISIX at technical conferences? Then this might just be the right career for you.
-4. Finding "ways to grow the product exponentially" and "new technology directions" from user scenarios and usage, and helping customers succeed, is the main and most exciting part of this job.
+- Are you eager to share brand new technologies with the world?
+- Do you love connecting with community members in a variety of ways, whether it's face-to-face, blogs, forums or other social channels and events?
+- Do you love sharing your enthusiasm for Apache APISIX at technical conferences? Then this might just be the right career for you.
+- Finding "ways to grow the product exponentially" and "new technology directions" from user scenarios and usage, and helping customers succeed, is the main and most exciting part of this job.
 
-### Requirements
+## Requirements
 
-1. Extensive experience in software development and operation and maintenance related work.
-2. Familiar with customers' industry needs, able to extract problems and corresponding solutions from them.
-3. Ability to produce engaging content - including presentation skills, blogs, slideshows, etc.
-4. Whether it's a face-to-face meeting or an executive office, You will be able to deliver your presentation with ease.
+- Extensive experience in software development and operation and maintenance related work.
+- Familiar with customers' industry needs, able to extract problems and corresponding solutions from them.
+- Ability to produce engaging content - including presentation skills, blogs, slideshows, etc.
+- Whether it's a face-to-face meeting or an executive office, You will be able to deliver your presentation with ease.
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/front-end-engineer.md
+++ b/_posts/careers/en-US/front-end-engineer.md
@@ -2,23 +2,23 @@
 title: Front-end Engineer
 date: 2021-03-19 17:20:00
 ---
-### Content
+## Content
 
-1. Responsible for the front-end development and design of the company's products;
-2. Responsible for the development and improvement of base libraries, frameworks and key modules;
-3. Work with the overall technical team to optimize the development methods and processes and specifications of the front-end team and improve team efficiency.
+- Responsible for the front-end development and design of the company's products;
+- Responsible for the development and improvement of base libraries, frameworks and key modules;
+- Work with the overall technical team to optimize the development methods and processes and specifications of the front-end team and improve team efficiency.
 
-### Requirements
+## Requirements
 
-1. Proficiency in front-end frameworks such as jQuery, Bootstrap, Ant Design and familiarity with objectified Javascript programming;
-2. Experience in the development of enterprise products or SaaS;
-3. Knowledge of user experience, interaction and user requirement analysis, product or interface design experience is preferred;
-4. Strong self-learning ability, relatively high enthusiasm and concern for front-end cutting-edge areas, good execution, good willingness to communicate and collaborate, and focus on efficiency.
+- Proficiency in front-end frameworks such as jQuery, Bootstrap, Ant Design and familiarity with objectified Javascript programming;
+- Experience in the development of enterprise products or SaaS;
+- Knowledge of user experience, interaction and user requirement analysis, product or interface design experience is preferred;
+- Strong self-learning ability, relatively high enthusiasm and concern for front-end cutting-edge areas, good execution, good willingness to communicate and collaborate, and focus on efficiency.
 
-### Additional
+## Additional
 
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/go-engineer.md
+++ b/_posts/careers/en-US/go-engineer.md
@@ -3,22 +3,22 @@ title: Go Engineer
 date: 2020-10-17 15:03:00
 ---
 
-### Content
+## Content
 
-1. Responsible for the design and architecture of the Apache APISIX control plane;
-2. Completes control plane function development in conjunction with front and back end development;
-3. Participated in the development of Apache APISIX as a core contributor.
+- Responsible for the design and architecture of the Apache APISIX control plane;
+- Completes control plane function development in conjunction with front and back end development;
+- Participated in the development of Apache APISIX as a core contributor.
 
-### Requirements
+## Requirements
 
-1. Familiarity with projects and specifications for control planes such as Istio, SMI, etc.;
-2. Good coding habits, comfortable with test-driven development;
-3. Good English literacy skills;
-4. Contributors to open source projects preferred.
+- Familiarity with projects and specifications for control planes such as Istio, SMI, etc.;
+- Good coding habits, comfortable with test-driven development;
+- Good English literacy skills;
+- Contributors to open source projects preferred.
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/head-of-developer-relations-and-ecology.md
+++ b/_posts/careers/en-US/head-of-developer-relations-and-ecology.md
@@ -9,23 +9,23 @@ Our users and contributors in the community have provided a great deal of suppor
 
 As our Developer Relations and Ecology Lead, you will be a solid support to the community.
 
-### Content
+## Content
 
-1. Connecting with members of the open source community in a variety of ways, whether face-to-face, blogs, forums, or other social channels and events.
-2. Communicating with partners and building a global API ecosystem together.
-3. Let APISIX run in more enterprises and complete more large-flow challenges;
-4. This position supports telecommuting.
+- Connecting with members of the open source community in a variety of ways, whether face-to-face, blogs, forums, or other social channels and events.
+- Communicating with partners and building a global API ecosystem together.
+- Let APISIX run in more enterprises and complete more large-flow challenges;
+- This position supports telecommuting.
 
-### Requirements
+## Requirements
 
-1. Understanding of the open source community and identification with the open source culture.
-2. Good in dealing with engineers.
-3. Happy to work with remote distribution teams.
-4. Solid writing skills and the ability to produce engaging content - including presentations, blogs, videos, etc.
+- Understanding of the open source community and identification with the open source culture.
+- Good in dealing with engineers.
+- Happy to work with remote distribution teams.
+- Solid writing skills and the ability to produce engaging content - including presentations, blogs, videos, etc.
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/head-of-growth.md
+++ b/_posts/careers/en-US/head-of-growth.md
@@ -3,24 +3,24 @@ title: Head of Growth
 date: 2020-11-17 21:16:00
 ---
 
-### Content
+## Content
 
-1. Growthing of open source communities and company commercial products;
-2. Sort out, follow up and optimize sales leads;
-3. Competitive products and industry analysis;
-4. Build growth team.
+- Growthing of open source communities and company commercial products;
+- Sort out, follow up and optimize sales leads;
+- Competitive products and industry analysis;
+- Build growth team.
 
-### Requirements
+## Requirements
 
-1. Strong communication skills and proactive;
-2. Sensitive to data;
-3. More than 3 years of toB growth experience, international experience is preferred;
-4. Fluent oral English, experience in overseas media and consulting companies is preferred;
-5. Have participated in open source community is preferred.
+- Strong communication skills and proactive;
+- Sensitive to data;
+- More than 3 years of toB growth experience, international experience is preferred;
+- Fluent oral English, experience in overseas media and consulting companies is preferred;
+- Have participated in open source community is preferred.
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/senior-development-engineer.md
+++ b/_posts/careers/en-US/senior-development-engineer.md
@@ -3,22 +3,22 @@ title: Senior Development Engineer
 date: 2020-10-19 13:19:00
 ---
 
-### Content
+## Content
 
-1. Development of Next-Generation API Management and Analysis Platform Based on Apache APISIX;
-2. Stay technologically innovative in API's big data, behavioral analytics, security, cloud-native and other areas;
-3. Participated in the development of Apache APISIX as a core contributor.
+- Development of Next-Generation API Management and Analysis Platform Based on Apache APISIX;
+- Stay technologically innovative in API's big data, behavioral analytics, security, cloud-native and other areas;
+- Participated in the development of Apache APISIX as a core contributor.
 
-### Requirements
+## Requirements
 
-1. In-depth knowledge of Apache APISIX, Kong, Envoy, Nginx and other gateways or Web Server projects, with secondary development skills;
-2. Good coding habits, comfortable with test-driven development;
-3. Good English literacy skills;
-4. Contributors to open source projects preferred;
+- In-depth knowledge of Apache APISIX, Kong, Envoy, Nginx and other gateways or Web Server projects, with secondary development skills;
+- Good coding habits, comfortable with test-driven development;
+- Good English literacy skills;
+- Contributors to open source projects preferred;
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/senior-nginx-development-engineer.md
+++ b/_posts/careers/en-US/senior-nginx-development-engineer.md
@@ -3,21 +3,21 @@ title: Senior Nginx Development Engineer
 date: 2020-10-19 13:19:00
 ---
 
-### Content
+## Content
 
-1. Responsible for Nginx underlay optimization for Apache APISIX;
-2. Responsible for development, maintenance, and upgrades of the Nginx kernel and third-party modules;
+- Responsible for Nginx underlay optimization for Apache APISIX;
+- Responsible for development, maintenance, and upgrades of the Nginx kernel and third-party modules;
 
-### Requirements
+## Requirements
 
-1. Knowledge of Nginx principles and implementation;
-2. Developed Nginx C modules;
-3. Loves open source and has a strong interest in technology;
-4. Nginx, OpenResty code contributors are preferred;
+- Knowledge of Nginx principles and implementation;
+- Developed Nginx C modules;
+- Loves open source and has a strong interest in technology;
+- Nginx, OpenResty code contributors are preferred;
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/server-development-engineer.md
+++ b/_posts/careers/en-US/server-development-engineer.md
@@ -3,15 +3,15 @@ title: Server Development Engineer (Internship)
 date: 2021-02-23 11:03:00
 ---
 
-### Internship Content
+## Internship Content
 
-1. completing development tasks for Apache APISIX and surrounding open source projects.
-2. Improving development documentation in English and Chinese.
-3. Collect user feedback and draw lessons from it.
+- completing development tasks for Apache APISIX and surrounding open source projects.
+- Improving development documentation in English and Chinese.
+- Collect user feedback and draw lessons from it.
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/technical-support-engineer.md
+++ b/_posts/careers/en-US/technical-support-engineer.md
@@ -3,22 +3,22 @@ title: Technical Support Engineer
 date: 2020-10-19 13:19:00
 ---
 
-### Content
+## Content
 
-1. Provide after-sales technical support for Apache APISIX, APISEVEN and other API gateway products and solutions to solve user problems and ensure stable operation of the system;
-2. Troubleshoot problems and failures in the user's environment, reproduce and locate them. Improve documentation and manuals to help users use the product better.
+- Provide after-sales technical support for Apache APISIX, APISEVEN and other API gateway products and solutions to solve user problems and ensure stable operation of the system;
+- Troubleshoot problems and failures in the user's environment, reproduce and locate them. Improve documentation and manuals to help users use the product better.
 
-### Requirements
+## Requirements
 
-1. Familiarity with the operation of Linux systems;
-2. Good literacy in English;
-3. Ability to locate and reproduce problems;
-4. Good oral and written communication skills;
-5. Familiar with API gateway products and interested in open source is a plus;
+- Familiarity with the operation of Linux systems;
+- Good literacy in English;
+- Ability to locate and reproduce problems;
+- Good oral and written communication skills;
+- Familiar with API gateway products and interested in open source is a plus;
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/_posts/careers/en-US/technical-writer.md
+++ b/_posts/careers/en-US/technical-writer.md
@@ -3,23 +3,23 @@ title: Technical Writer
 date: 2021-02-23 11:10:00
 ---
 
-### Content
+## Content
 
-1. Develop and maintain User Manuals, Operation Instructions, etc. for all products.
-2. Provide better understanding of products for the users with in-depth understanding of product functions, work alongside the experience team to develop high-quality technical documentations.
-3. Research on other competitors' user manuals and sum up the advantages that can be learnt from.
-4. Passionate and creative in combining document writing and design for overall creative technical documentations.
+- Develop and maintain User Manuals, Operation Instructions, etc. for all products.
+- Provide better understanding of products for the users with in-depth understanding of product functions, work alongside the experience team to develop high-quality technical documentations.
+- Research on other competitors' user manuals and sum up the advantages that can be learnt from.
+- Passionate and creative in combining document writing and design for overall creative technical documentations.
 
-### Requirements
+## Requirements
 
-1. 3+ years of experience with technical writing.
-2. Excellent English written and content development skills.
-3. Proven ability to quickly learn and understand products. Passionate in technical writing.
-4. Good communication skills. Be highly self-motivated and well organized.
+- 3+ years of experience with technical writing.
+- Excellent English written and content development skills.
+- Proven ability to quickly learn and understand products. Passionate in technical writing.
+- Good communication skills. Be highly self-motivated and well organized.
 
-### Additional
+## Additional
 We're a remote work company with employees in 6 cities across China, and we do all of our collaboration through GitHub, Slack and Google Docs.
 
-### Contact
+## Contact
 
 [wenming@api7.ai](mailto:wenming@api7.ai)

--- a/views/Post/style.ts
+++ b/views/Post/style.ts
@@ -24,9 +24,9 @@ export const SBox1 = styled.div`
   h1 {
     text-align: left;
     color: rgba(41, 41, 41, 1);
-    font-family: fell, Georgia, Cambria, "Times New Roman", Times, serif;
+    font-family: Segoe UI;
     font-size: 48px;
-    font-weight: 400;
+    font-weight: 600;
     line-height: 60px;
   }
 
@@ -139,19 +139,19 @@ export const SBox2 = styled.div`
 
 export const SArticle = styled.article`
   font-size: 16px;
-  font-family: initial;
-  font-weight: 300;
+  font-family: revert;
+  font-weight: 400;
   line-height: 1.618;
-  color: #586376;
-  word-break: break-all;
-
+  word-break: break-word;
+  color: #292929;
+  
   p {
     margin: 20px 0;
   }
 
   h2 {
     font-size: 24px;
-    font-weight: 400;
+    font-weight: 500;
     line-height: 30px;
   }
 


### PR DESCRIPTION
This PR is related to fix of two issues I noticed in the "posts" pages i.e. job-descriptions and blogs for this case. 
They are -

- Irregular word-breaks in blogs and job descriptions at line-ends. For example, the "Front-end engineer" job-description page and Ingress controller blog, as mentioned below.

![before-jobDesc](https://user-images.githubusercontent.com/57267960/114112584-49a92580-98fa-11eb-826b-a0eb470ad53b.png)

![before-blog](https://user-images.githubusercontent.com/57267960/114112598-4d3cac80-98fa-11eb-992c-0306d0daecd2.png)

- Also, font styling in these pages are uneven. For example: headings in job descriptions, uneven font schemes etc.


Screenshots with issues fixes -

![After-jobDesc](https://user-images.githubusercontent.com/57267960/114112898-fc798380-98fa-11eb-8587-fb8e168b39d3.png)
Brought uniformity in font families and replaced ordered list with unordered list on job descriptions. Also, made the font little darker in color for its equal importance.

![After-blog](https://user-images.githubusercontent.com/57267960/114112992-45c9d300-98fb-11eb-92b1-ff5e02975b38.png)
