### PR TITLE
fix: typo on the About page

### DIFF
--- a/data/about.json
+++ b/data/about.json
@@ -47,7 +47,7 @@
       },
       {
         "date": "2019 年 8 月",
-        "desc": "第一家客户在生成环境上线"
+        "desc": "第一家客户在生产环境上线"
       },
       {
         "date": "2019 年 7 月",
@@ -105,7 +105,7 @@
       },
       {
         "date": "August 2019",
-        "desc": "First customer goes live in the generation environment"
+        "desc": "First customer goes live in the production environment"
       },
       {
         "date": "July 2019",


### PR DESCRIPTION
This PR aims to fix some typos:

- [x] 生成环境 -> 生产环境
- [x] generation environment -> production environment