### PR TITLE
fix: use correct links for Request Demo

### DIFF
--- a/_posts/page/en-US/form-api7-trial.md
+++ b/_posts/page/en-US/form-api7-trial.md
@@ -1,6 +1,0 @@
----
-title: "Try API7"
-date: 2020-12-23 22:00:00
----
-
-<iframe src="https://apiseven.mikecrm.com/VKHtla0" frameborder="0" scrolling="no" style="display: block; min-width: 100%; width: 100px; height: 1100px; border: none; overflow: auto;"></iframe>

--- a/_posts/page/zh-CN/form-api7-trial.md
+++ b/_posts/page/zh-CN/form-api7-trial.md
@@ -1,6 +1,0 @@
----
-title: "API7 预约演示"
-date: 2020-11-12 18:18:00
----
-
-<iframe src="https://apiseven.mikecrm.com/pvdVjd5" frameborder="0" scrolling="no" style="display: block; min-width: 100%; width: 100px; height: 900px; border: none; overflow: auto;"></iframe>

--- a/components/Navbar/NavContent.tsx
+++ b/components/Navbar/NavContent.tsx
@@ -61,7 +61,7 @@ const MobileNavContext = ({ links, language, ...props }: Props) => {
             </NavLink.Mobile>
           ),
         )}
-        <Button as="a" href="https://dashboard.apiseven.com" target="_blank" colorScheme="blue" w="full" size="lg" mt="5" _hover={{ color: "var(--chakra-colors-white)", background: "var(--chakra-colors-blue-600)", textDecoration: "none" }}>
+        <Button as="a" href="/form-api7-trial" target="_blank" colorScheme="blue" w="full" size="lg" mt="5" _hover={{ color: "var(--chakra-colors-white)", background: "var(--chakra-colors-blue-600)", textDecoration: "none" }}>
           {language === 'zh-CN' ? '申请试用' : 'Request Demo'}
         </Button>
 
@@ -106,7 +106,7 @@ const DesktopNavContent = ({ links, language, ...props }: Props) => {
         ))}
       </HStack>
       <HStack spacing="8" minW="240px" justify="space-between">
-        <Button as="a" href="https://dashboard.apiseven.com" target="_blank" colorScheme="blue" fontWeight="bold" _hover={{ color: "var(--chakra-colors-white)", background: "var(--chakra-colors-blue-600)", textDecoration: "none" }}>
+        <Button as="a" href="/form-api7-trial" target="_blank" colorScheme="blue" fontWeight="bold" _hover={{ color: "var(--chakra-colors-white)", background: "var(--chakra-colors-blue-600)", textDecoration: "none" }}>
           {language === 'zh-CN' ? '申请试用' : 'Request Demo'}
         </Button>
 

--- a/components/Navbar/NavContent.tsx
+++ b/components/Navbar/NavContent.tsx
@@ -19,6 +19,7 @@ import { NavMenu } from './NavMenu'
 import { Submenu } from './Submenu'
 import { ToggleButton } from './ToggleButton'
 import { Link } from './_data'
+import { getRequestDemoLink } from '../../helper'
 
 type Props = FlexProps & {
   links: Link[];
@@ -61,7 +62,7 @@ const MobileNavContext = ({ links, language, ...props }: Props) => {
             </NavLink.Mobile>
           ),
         )}
-        <Button as="a" href="/form-api7-trial" target="_blank" colorScheme="blue" w="full" size="lg" mt="5" _hover={{ color: "var(--chakra-colors-white)", background: "var(--chakra-colors-blue-600)", textDecoration: "none" }}>
+        <Button as="a" href={getRequestDemoLink(language)} target="_blank" colorScheme="blue" w="full" size="lg" mt="5" _hover={{ color: "var(--chakra-colors-white)", background: "var(--chakra-colors-blue-600)", textDecoration: "none" }}>
           {language === 'zh-CN' ? '申请试用' : 'Request Demo'}
         </Button>
 
@@ -106,7 +107,7 @@ const DesktopNavContent = ({ links, language, ...props }: Props) => {
         ))}
       </HStack>
       <HStack spacing="8" minW="240px" justify="space-between">
-        <Button as="a" href="/form-api7-trial" target="_blank" colorScheme="blue" fontWeight="bold" _hover={{ color: "var(--chakra-colors-white)", background: "var(--chakra-colors-blue-600)", textDecoration: "none" }}>
+        <Button as="a" href={getRequestDemoLink(language)} target="_blank" colorScheme="blue" fontWeight="bold" _hover={{ color: "var(--chakra-colors-white)", background: "var(--chakra-colors-blue-600)", textDecoration: "none" }}>
           {language === 'zh-CN' ? '申请试用' : 'Request Demo'}
         </Button>
 

--- a/components/Navbar/NavLink.tsx
+++ b/components/Navbar/NavLink.tsx
@@ -18,6 +18,7 @@ const DesktopNavLink = React.forwardRef<HTMLAnchorElement, NavLinkProps>((props,
       color={mode('gray.600', 'gray.400')}
       transition="all 0.2s"
       {...rest}
+      target={rest.href?.startsWith('/') ? '_self' : '_blank'}
       _hover={{ color: 'gray.500' }}
       _active={{ color: 'blue.600' }}
       _activeLink={{
@@ -40,6 +41,7 @@ export const MobileNavLink = (props: NavLinkProps) => {
       height="14"
       fontWeight="semibold"
       borderBottomWidth="1px"
+      target={rest.href?.startsWith('/') ? '_self' : '_blank'}
       {...rest}
     />
   )

--- a/components/Navbar/Submenu.tsx
+++ b/components/Navbar/Submenu.tsx
@@ -64,7 +64,7 @@ const MobileSubMenu = (props: SubmenuProps) => {
       <Collapse in={isOpen}>
         <Box pl="5">
           {link.children?.map((item, idx) => (
-            <NavLink.Mobile key={idx} href={item.href}>
+            <NavLink.Mobile key={idx} href={item.href} target={item.href.startsWith('/') ? '_self' : '_blank'}>
               {item.label}
             </NavLink.Mobile>
           ))}

--- a/components/Navbar/SubmenuItem.tsx
+++ b/components/Navbar/SubmenuItem.tsx
@@ -29,6 +29,7 @@ export const SubmenuItem = (props: SubmenuItemProps) => {
       alignItems="flex-start"
       transition="all 0.2s"
       rounded="lg"
+      target={href.startsWith('/') ? '_self' : '_blank'}
       _hover={{ bg: mode('gray.50', 'gray.600') }}
       _focus={{ shadow: 'outline' }}
       {...rest}

--- a/components/Navbar/_data.tsx
+++ b/components/Navbar/_data.tsx
@@ -7,6 +7,8 @@ import { SiMeetup } from 'react-icons/si'
 import { MdCompare } from 'react-icons/md'
 import { TiNews } from 'react-icons/ti'
 
+import { getRequestDemoLink } from '../../helper'
+
 export interface Link {
   label: string
   href?: string
@@ -106,7 +108,7 @@ export const EN_US_Links: Link[] = [
       {
         label: 'Request Demo',
         description: 'Contact us and request demo',
-        href: '/form-api7-trial',
+        href: getRequestDemoLink('en-US'),
         icon: <MdWeb />,
       }, {
         label: 'Business Support',
@@ -188,7 +190,7 @@ export const ZH_CN_Links: Link[] = [
       }, {
         label: '预约演示',
         description: '联系我们，预约产品演示。',
-        href: '/form-api7-trial',
+        href: getRequestDemoLink('zh-CN'),
         icon: <IoCalendar />,
       }, {
         label: "Apache APISIX vs API7",

--- a/helper.ts
+++ b/helper.ts
@@ -1,0 +1,6 @@
+export const getRequestDemoLink = (language = 'en-US') => {
+  if (language === 'zh-CN') {
+    return 'https://apiseven.mikecrm.com/pvdVjd5'
+  }
+  return 'https://apiseven.mikecrm.com/VKHtla0'
+}

--- a/views/About/About.tsx
+++ b/views/About/About.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import { NextPage } from "next";
 import { TFunction } from "next-i18next";
 import { NextSeo } from "next-seo";
@@ -7,10 +7,12 @@ import {
   VerticalTimelineElement,
 } from "react-vertical-timeline-component";
 import "react-vertical-timeline-component/style.min.css";
+import { I18nContext } from "react-i18next";
 
 import { withTranslation } from "../../i18n";
 import { SWrapper } from "./style";
 import data from "../../data/about.json";
+import { getRequestDemoLink } from '../../helper'
 
 type Props = {
   t: TFunction;
@@ -18,6 +20,10 @@ type Props = {
 };
 
 const About: NextPage<Props, any> = ({ t, list = [] }) => {
+  const {
+    i18n: { language },
+  } = useContext(I18nContext);
+
   return (
     <SWrapper>
       <NextSeo title={t(`common:about`)} />
@@ -149,7 +155,7 @@ const About: NextPage<Props, any> = ({ t, list = [] }) => {
                 </p>
               </div>
               <div>
-                <a href="/form-api7-trial" target="_blank">
+                <a href={getRequestDemoLink(language)} target="_blank">
                   <span className="tip">{t("about-contact-detail2")}</span>
                 </a>
               </div>

--- a/views/Home/components/HomeCTA/index.tsx
+++ b/views/Home/components/HomeCTA/index.tsx
@@ -1,16 +1,21 @@
 import { Box, Button, Heading, Stack, Text, useColorModeValue } from '@chakra-ui/react'
 import React, { useContext } from "react";
-import { NextSeo } from "next-seo";
 import { TFunction } from "next-i18next";
 import { I18nContext } from "react-i18next";
 import { NextPage } from "next";
 import { withTranslation } from 'i18n';
+
+import { getRequestDemoLink } from '../../../../helper'
 
 type Props = {
   t: TFunction;
 };
 
 const App: NextPage<Props, any> = ({ t }) => {
+  const {
+    i18n: { language },
+  } = useContext(I18nContext);
+
   return (
     <Box as="section">
       <Box
@@ -55,7 +60,8 @@ const App: NextPage<Props, any> = ({ t }) => {
         >
           <Button
             as="a"
-            href="/form-api7-trial"
+            href={getRequestDemoLink(language)}
+            target="_blank"
             size="lg"
             h="16"
             px="10"


### PR DESCRIPTION
This PR aims to update the Request Demo link, and remove the form-trial page, due to https://www.mikecrm.com/ doesn't support iframe directly.

fix #71 

![image](https://user-images.githubusercontent.com/2106987/121642708-7c6ec600-cac3-11eb-85d8-f0378220562e.png)
