### PR TITLE
feat: hidden banner after browser reopen

### DIFF
--- a/components/HomeBanner/index.tsx
+++ b/components/HomeBanner/index.tsx
@@ -13,7 +13,7 @@ const App: NextPage<Props, any> = ({ t }) => {
   const [show, setShow] = useState(false)
 
   useEffect(() => {
-    if (sessionStorage.getItem("DISABLE_HOME_BANNER") === "true") {
+    if (localStorage.getItem("DISABLE_HOME_BANNER") === "true") {
       return
     }
 
@@ -57,7 +57,7 @@ const App: NextPage<Props, any> = ({ t }) => {
           aria-label="Close Banner"
           icon={<HiX />}
           onClick={() => {
-            sessionStorage.setItem("DISABLE_HOME_BANNER", "true")
+            localStorage.setItem("DISABLE_HOME_BANNER", "true")
             setShow(false)
           }}
         />


### PR DESCRIPTION
This PR aims to hidden the banner even when reopening the browser.

这个 PR 用于实现：重新访问浏览器，依然隐藏 Banner。目前方案没有考虑：更换 Banner 信息后，如何让新的消息显示出来？ https://github.com/api7/website/issues/142